### PR TITLE
Add a link to the GitHub repository for queue

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -30,7 +30,7 @@
         </style>
     </head>
     <body>
-        <h1>Homu queue - {{repo_label}}</h1>
+        <h1>Homu queue - <a href="https://github.com/{{repo_label}}">{{repo_label}}</a></h1>
 
         <p>
             <button type="button" id="rollup">Create a rollup</button>


### PR DESCRIPTION

PR ported from [84](https://github.com/barosl/homu/pull/84). Originally submitted by @mrmonday on Sun Jun 14 16:01:12 2015. 

------------------------------------------------------------------------------

This adds a link back to the GitHub repository for a project, from the queue.

