### PR TITLE
reorder columns to make most important info first

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -52,12 +52,12 @@
                     <th><input type="checkbox"></th>
                     <th>#</th>
                     <th>Status</th>
-                    <th>Priority</th>
-                    <th>Head ref</th>
-                    <th>Title</th>
-                    <th>Approved by</th>
                     <th>Mergeable</th>
+                    <th>Title</th>
+                    <th>Head ref</th>
                     <th>Assignee</th>
+                    <th>Approved by</th>
+                    <th>Priority</th>
                 </tr>
             </thead>
 
@@ -68,12 +68,12 @@
                     <td><input type="checkbox" data-num="{{state.num}}"></td>
                     <td><a href="{{state.url}}">{{state.num}}</a></td>
                     <td class="{{state.status}}">{{state.status}}{{state.status_ext}}</td>
-                    <td>{{state.priority}}</td>
-                    <td>{{state.head_ref}}</td>
-                    <td>{{state.title}}</td>
-                    <td>{{state.approved_by}}</td>
                     <td class="{{state.mergeable}}">{{state.mergeable}}</td>
+                    <td>{{state.title}}</td>
+                    <td>{{state.head_ref}}</td>
                     <td>{{state.assignee}}</td>
+                    <td>{{state.approved_by}}</td>
+                    <td>{{state.priority}}</td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION

PR ported from [79](https://github.com/barosl/homu/pull/79). Originally submitted by @Gankro on Wed May 20 21:29:19 2015. 
